### PR TITLE
earthly 0.5.19

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -1,8 +1,8 @@
 class Earthly < Formula
   desc "Build automation tool for the container era"
   homepage "https://earthly.dev/"
-  url "https://github.com/earthly/earthly/archive/v0.5.18.tar.gz"
-  sha256 "b7679ae11f76536033de59c27c22ea6ca426d3e876fa61aa389d0710ac639c81"
+  url "https://github.com/earthly/earthly/archive/v0.5.19.tar.gz"
+  sha256 "0841c0e67fe8102fcbfc4fad8d87dafbcf1de775e5991aa931222b8791ca00b6"
   license "BUSL-1.1"
   head "https://github.com/earthly/earthly.git"
 
@@ -12,7 +12,7 @@ class Earthly < Formula
   end
 
   bottle do
-    root_url "https://github.com/earthly/homebrew-earthly/releases/download/earthly-0.5.18"
+    root_url "https://github.com/earthly/earthly/archive/v0.5.19.tar.gz"
     rebuild 1
     sha256 cellar: :any_skip_relocation, catalina:     "45460a8adb85ad67bfaf58fd54cf0f7519c52eb85032ffac70a9c20e90ec8b0f"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "0604bc83c6c79762549be7ce226a209cc58cdaf63c81c3e983f380ee0c8e92f9"
@@ -22,7 +22,7 @@ class Earthly < Formula
 
   def install
     ldflags = "-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} " \
-              "-X main.GitSha=0cb24b0a8bbe4253e96990b7947e18f684918298 "
+              "-X main.GitSha=e37f7a5687511930040659a509e048e314d9a6a1 "
     tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork"
     system "go", "build",
         "-tags", tags,


### PR DESCRIPTION
-------------

#### Debug data

PR generated by the [Earthly build](https://github.com/earthly/earthly/blob/main/release/Earthfile) (target +release-homebrew)

* `RELEASE_TAG=v0.5.19`

* `GIT_USERNAME=griswoldthecat`

* `NEW_URL=https://github.com/earthly/earthly/archive/v0.5.19.tar.gz`

* `NEW_SHA256=0841c0e67fe8102fcbfc4fad8d87dafbcf1de775e5991aa931222b8791ca00b6`

* `TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork`

* `LDFLAGS=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} -X main.GitSha=e37f7a5687511930040659a509e048e314d9a6a1 `

* `LDFLAGS1=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} `

* `LDFLAGS2=-X main.GitSha=e37f7a5687511930040659a509e048e314d9a6a1 `