### PR TITLE
earthly 0.5.20

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -1,8 +1,8 @@
 class Earthly < Formula
   desc "Build automation tool for the container era"
   homepage "https://earthly.dev/"
-  url "https://github.com/earthly/earthly/archive/v0.5.19.tar.gz"
-  sha256 "0841c0e67fe8102fcbfc4fad8d87dafbcf1de775e5991aa931222b8791ca00b6"
+  url "https://github.com/earthly/earthly/archive/v0.5.20.tar.gz"
+  sha256 "0829f599a22873113da4f10d12c6b7cd8d1aed1ec718d2c671f837e94c506f12"
   license "BUSL-1.1"
   head "https://github.com/earthly/earthly.git"
 
@@ -12,7 +12,7 @@ class Earthly < Formula
   end
 
   bottle do
-    root_url "https://github.com/earthly/homebrew-earthly/releases/download/earthly-0.5.19"
+    root_url "https://github.com/earthly/earthly/archive/v0.5.20.tar.gz"
     sha256 cellar: :any_skip_relocation, catalina:     "0bd98dd115bddfa468b0718d7293f3bd9539d22b5aab9265c603ee6b85e5ce4d"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "edfa89148545a71ca40ca0d5c98d57cc7d16cfad88ff7a81b56ff35b86cc20d4"
   end
@@ -21,7 +21,7 @@ class Earthly < Formula
 
   def install
     ldflags = "-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} " \
-              "-X main.GitSha=e37f7a5687511930040659a509e048e314d9a6a1 "
+              "-X main.GitSha=1e0503a3f92e8dfed9fbc43a68692421d64be256 "
     tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork"
     system "go", "build",
         "-tags", tags,


### PR DESCRIPTION
-------------

#### Debug data

PR generated by the [Earthly build](https://github.com/earthly/earthly/blob/main/release/Earthfile) (target +release-homebrew)

* `RELEASE_TAG=v0.5.20`

* `GIT_USERNAME=griswoldthecat`

* `NEW_URL=https://github.com/earthly/earthly/archive/v0.5.20.tar.gz`

* `NEW_SHA256=0829f599a22873113da4f10d12c6b7cd8d1aed1ec718d2c671f837e94c506f12`

* `TAGS=dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork`

* `LDFLAGS=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} -X main.GitSha=1e0503a3f92e8dfed9fbc43a68692421d64be256 `

* `LDFLAGS1=-X main.DefaultBuildkitdImage=earthly/buildkitd:v#{version} -X main.Version=v#{version} `

* `LDFLAGS2=-X main.GitSha=1e0503a3f92e8dfed9fbc43a68692421d64be256 `